### PR TITLE
feat(scan): add .eml upload form with server-side validation (no parsing)

### DIFF
--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -5,18 +5,37 @@
   </x-slot>
 
   <div class="p-6">
-    {{-- Uniform card look --}}
-    <div class="max-w-3xl mx-auto bg-white shadow rounded-xl p-6 space-y-4">
-      <p class="text-gray-700">
-        This page will let you upload a <code>.eml</code> file and parse it in memory
-        (no full email content will be stored). For now it is a placeholder.
-      </p>
+    <div class="max-w-3xl mx-auto bg-white shadow rounded-xl p-6 space-y-6 dark:bg-gray-800 dark:text-gray-100">
+      {{-- Upload form: POST + multipart/form-data to send file --}}
+      <form method="POST" action="{{ route('scan.store') }}" enctype="multipart/form-data" class="space-y-4">
+        @csrf
 
-      {{-- Quick actions --}}
-      <div class="flex items-center gap-3">
-        <x-secondary-button onclick="window.location='{{ route('scan.history') }}'">Go to history</x-secondary-button>
-        <x-secondary-button onclick="window.location='{{ route('stats') }}'">View stats</x-secondary-button>
-      </div>
+        {{-- File input: backend will read request()->file('eml') --}}
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+            Upload .eml file
+          </label>
+          <input type="file" name="eml" accept=".eml" required class="block w-full">
+          <p class="text-xs text-gray-500 mt-1">Max 15MB, MIME: message/rfc822</p>
+
+          {{-- Server-side validation error for the file input --}}
+          @error('eml')
+            <p class="text-red-600 mt-1">{{ $message }}</p>
+          @enderror
+        </div>
+
+        <x-primary-button>Upload</x-primary-button>
+      </form>
+
+      {{-- Success flash message (from POST handler) --}}
+      @if (session('ok'))
+        <div class="text-green-700 dark:text-green-400">✅ {{ session('ok') }}</div>
+      @endif>
+
+      {{-- Simple guidance (no parsing yet) --}}
+      <p class="text-sm text-gray-600 dark:text-gray-300">
+        This step only validates and accepts the .eml upload. Parsing comes next.
+      </p>
     </div>
   </div>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,22 +2,36 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ProfileController;
+use Illuminate\Http\Request;
 
 // ---------- Public pages ----------
 Route::view('/', 'home')->name('home');          // serves resources/views/home.blade.php
 Route::view('/about', 'about')->name('about');   // serves resources/views/about.blade.php
 
 // ---------- Dashboard (Breeze redirect after registration) ----------
-// Use Route::view(...)->middleware([...])  (correct chaining)
 Route::view('/dashboard', 'dashboard')
     ->middleware(['auth', 'verified'])
     ->name('dashboard');
 
 // ---------- Private pages (login + verified email required) ----------
 Route::middleware(['auth', 'verified'])->group(function () {
+    // GET: scan page (form)
     Route::view('/scan', 'create')->name('scan.create');        // serves resources/views/create.blade.php
-    Route::view('/history', 'history')->name('scan.history');   // serves resources/views/history.blade.php
-    Route::view('/stats', 'stats')->name('stats');              // serves resources/views/stats.blade.php
+
+    // POST: scan upload handler (receives .eml file) — NO parsing here
+    Route::post('/scan', function (Request $request) {
+        // Server-side validation: require .eml file, correct MIME, max 15MB
+        $request->validate([
+            'eml' => ['required', 'file', 'mimetypes:message/rfc822', 'max:15360'],
+        ]);
+
+        // Only confirm receipt; parsing will be implemented next
+        return back()->with('ok', 'File received successfully.');
+    })->name('scan.store');
+
+    // Other protected pages (placeholders)
+    Route::view('/history', 'history')->name('scan.history');   // resources/views/history.blade.php
+    Route::view('/stats', 'stats')->name('stats');              // resources/views/stats.blade.php
 });
 
 // ---------- Breeze profile pages (login required) ----------


### PR DESCRIPTION
- add POST form (multipart) on /scan with CSRF protection

- validate .eml MIME (message/rfc822) and max size 15MB

- display validation errors under input field

- return success flash message without storing or parsing the file