### PR TITLE
chore(upload): configure PHP limits and custom messages for .eml validation

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
         // Server-side validation: require .eml file, correct MIME, max 15MB
         $request->validate([
             'eml' => ['required', 'file', 'mimetypes:message/rfc822', 'max:15360'],
+        ], [
+            'eml.mimetypes' => 'Only .eml files are allowed.',
+            'eml.max' => 'The email must not exceed 15MB.',
         ]);
 
         // Only confirm receipt; parsing will be implemented next


### PR DESCRIPTION
- updated php.ini/.user.ini to set upload_max_filesize=20M and post_max_size=20M

- ensures Laravel validation enforces 15MB limit instead of PHP aborting early

- added custom error messages for clearer feedback (Only .eml files up to 15MB are allowed.)