### PR TITLE
refactor(scan): move upload handler to ScanController@store

### DIFF
--- a/app/Http/Controllers/ScanController.php
+++ b/app/Http/Controllers/ScanController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ScanController extends Controller
+{
+    /**
+     * Handle .eml upload (validation only, no parsing).
+     */
+    public function store(Request $request)
+    {
+        // Server-side validation: require .eml file, correct MIME, max 15MB
+        $request->validate(
+            [
+                'eml' => ['required', 'file', 'mimetypes:message/rfc822', 'max:15360'],
+            ],
+            // Optional: clearer custom messages
+            [
+                'eml.required'   => 'Please select a file.',
+                'eml.file'       => 'The upload must be a file.',
+                'eml.mimetypes'  => 'Only .eml files are allowed (MIME message/rfc822).',
+                'eml.max'        => 'The email must not exceed 15MB.',
+            ]
+        );
+
+        // No parsing yet — just acknowledge success
+        return back()->with('ok', 'File received successfully.');
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ProfileController;
-use Illuminate\Http\Request;
+use App\Http\Controllers\ScanController; // <-- add controller import
 
 // ---------- Public pages ----------
 Route::view('/', 'home')->name('home');          // serves resources/views/home.blade.php
@@ -18,19 +18,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // GET: scan page (form)
     Route::view('/scan', 'create')->name('scan.create');        // serves resources/views/create.blade.php
 
-    // POST: scan upload handler (receives .eml file) — NO parsing here
-    Route::post('/scan', function (Request $request) {
-        // Server-side validation: require .eml file, correct MIME, max 15MB
-        $request->validate([
-            'eml' => ['required', 'file', 'mimetypes:message/rfc822', 'max:15360'],
-        ], [
-            'eml.mimetypes' => 'Only .eml files are allowed.',
-            'eml.max' => 'The email must not exceed 15MB.',
-        ]);
-
-        // Only confirm receipt; parsing will be implemented next
-        return back()->with('ok', 'File received successfully.');
-    })->name('scan.store');
+    // POST: scan upload handler (controller, validation only — no parsing)
+    Route::post('/scan', [ScanController::class, 'store'])->name('scan.store');
 
     // Other protected pages (placeholders)
     Route::view('/history', 'history')->name('scan.history');   // resources/views/history.blade.php


### PR DESCRIPTION
- extracted .eml upload validation logic from route closure

- added ScanController with store() method (validation only, no parsing yet)

- updated routes/web.php to point POST /scan to controller

- behavior unchanged; prepares endpoint for upcoming parsing logic