### PR TITLE
feat(scan): parse .eml in memory with ZBateson and show summary

### DIFF
--- a/app/Http/Controllers/ScanController.php
+++ b/app/Http/Controllers/ScanController.php
@@ -3,29 +3,79 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use ZBateson\MailMimeParser\MailMimeParser;    // <-- new parser
+use ZBateson\MailMimeParser\Message;           // (optional type hint)
 
 class ScanController extends Controller
 {
-    /**
-     * Handle .eml upload (validation only, no parsing).
-     */
     public function store(Request $request)
     {
-        // Server-side validation: require .eml file, correct MIME, max 15MB
+        // 1) Validation unchanged
         $request->validate(
+            ['eml' => ['required', 'file', 'mimetypes:message/rfc822', 'max:15360']],
             [
-                'eml' => ['required', 'file', 'mimetypes:message/rfc822', 'max:15360'],
-            ],
-            // Optional: clearer custom messages
-            [
-                'eml.required'   => 'Please select a file.',
-                'eml.file'       => 'The upload must be a file.',
-                'eml.mimetypes'  => 'Only .eml files are allowed (MIME message/rfc822).',
-                'eml.max'        => 'The email must not exceed 15MB.',
+                'eml.required'  => 'Please select a file.',
+                'eml.file'      => 'The upload must be a file.',
+                'eml.mimetypes' => 'Only .eml files are allowed (MIME message/rfc822).',
+                'eml.max'       => 'The email must not exceed 15MB.',
             ]
         );
 
-        // No parsing yet — just acknowledge success
-        return back()->with('ok', 'File received successfully.');
+        // 2) Read from PHP's temp path (no persistence)
+        $tmpPath = $request->file('eml')->getRealPath();
+        $raw     = file_get_contents($tmpPath);
+
+        // 3) Parse in memory
+        $parser  = new MailMimeParser();
+        /** @var Message $message */
+        $message = $parser->parse($raw, false);
+
+        // 4) Extract simple metadata
+        $from    = $message->getHeaderValue('from');     // e.g. Alice <alice@example.com>
+        $to      = $message->getHeaderValue('to');
+        $subject = $message->getHeaderValue('subject');
+        $date    = $message->getHeaderValue('date');
+
+        // 5) Bodies (store only lengths)
+        $textBody = $message->getTextContent() ?? '';
+        $htmlBody = $message->getHtmlContent() ?? '';
+
+        // 6) Attachments count
+        $attachCount = count(iterator_to_array($message->getAllAttachmentParts()));
+
+        // 7) Sender domain (best‑effort)
+        $fromDomain = $this->extractDomainFromAddress($from);
+
+        // 8) Build result payload
+        $results = [
+            'from'        => $from,
+            'fromDomain'  => $fromDomain,
+            'to'          => $to,
+            'subject'     => $subject,
+            'date'        => $date,
+            'bodies'      => [
+                'textLength' => mb_strlen($textBody, 'UTF-8'),
+                'htmlLength' => mb_strlen($htmlBody, 'UTF-8'),
+            ],
+            'attachments' => [
+                'count' => $attachCount,
+            ],
+        ];
+
+        return back()->with('ok', 'File parsed in memory.')->with('results', $results);
+    }
+
+    private function extractDomainFromAddress(string $from): ?string
+    {
+        if (preg_match('/<([^>]+)>/', $from, $m)) {
+            $email = $m[1];
+        } elseif (preg_match('/[A-Z0-9._%+-]+@([A-Z0-9.-]+\.[A-Z]{2,})/i', $from, $m)) {
+            return strtolower($m[1]);
+        } else {
+            return null;
+        }
+
+        $parts = explode('@', $email);
+        return count($parts) === 2 ? strtolower($parts[1]) : null;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1"
+        "laravel/tinker": "^2.10.1",
+        "zbateson/mail-mime-parser": "^3.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6c73ea5dadcd971050eeb806511e47d",
+    "content-hash": "0ebda9f0cd9946c51d42af53ba068462",
     "packages": [
         {
             "name": "brick/math",
@@ -2512,6 +2512,134 @@
             "time": "2025-05-08T08:14:37+00:00"
         },
         {
+            "name": "php-di/invoker",
+            "version": "2.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-DI/Invoker.git",
+                "reference": "59f15608528d8a8838d69b422a919fd6b16aa576"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-DI/Invoker/zipball/59f15608528d8a8838d69b422a919fd6b16aa576",
+                "reference": "59f15608528d8a8838d69b422a919fd6b16aa576",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "psr/container": "^1.0|^2.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "mnapoli/hard-mode": "~0.3.0",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Invoker\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Generic and extensible callable invoker",
+            "homepage": "https://github.com/PHP-DI/Invoker",
+            "keywords": [
+                "callable",
+                "dependency",
+                "dependency-injection",
+                "injection",
+                "invoke",
+                "invoker"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-DI/Invoker/issues",
+                "source": "https://github.com/PHP-DI/Invoker/tree/2.3.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-17T12:49:27+00:00"
+        },
+        {
+            "name": "php-di/php-di",
+            "version": "7.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-DI/PHP-DI.git",
+                "reference": "f88054cc052e40dbe7b383c8817c19442d480352"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-DI/PHP-DI/zipball/f88054cc052e40dbe7b383c8817c19442d480352",
+                "reference": "f88054cc052e40dbe7b383c8817c19442d480352",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/serializable-closure": "^1.0 || ^2.0",
+                "php": ">=8.0",
+                "php-di/invoker": "^2.0",
+                "psr/container": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "friendsofphp/proxy-manager-lts": "^1",
+                "mnapoli/phpunit-easymock": "^1.3",
+                "phpunit/phpunit": "^9.6 || ^10 || ^11",
+                "vimeo/psalm": "^5|^6"
+            },
+            "suggest": {
+                "friendsofphp/proxy-manager-lts": "Install it if you want to use lazy injection (version ^1)"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "DI\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The dependency injection container for humans",
+            "homepage": "https://php-di.org/",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interop",
+                "dependency injection",
+                "di",
+                "ioc",
+                "psr11"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-DI/PHP-DI/issues",
+                "source": "https://github.com/PHP-DI/PHP-DI/tree/7.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/php-di/php-di",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-16T11:10:48+00:00"
+        },
+        {
             "name": "phpoption/phpoption",
             "version": "1.9.3",
             "source": {
@@ -4336,6 +4464,86 @@
             "time": "2024-09-09T11:45:10+00:00"
         },
         {
+            "name": "symfony/polyfill-iconv",
+            "version": "v1.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-iconv.git",
+                "reference": "5f3b930437ae03ae5dff61269024d8ea1b3774aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/5f3b930437ae03ae5dff61269024d8ea1b3774aa",
+                "reference": "5f3b930437ae03ae5dff61269024d8ea1b3774aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-iconv": "*"
+            },
+            "suggest": {
+                "ext-iconv": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Iconv extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "iconv",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.32.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-17T14:58:18+00:00"
+        },
+        {
             "name": "symfony/polyfill-intl-grapheme",
             "version": "v1.32.0",
             "source": {
@@ -5974,6 +6182,214 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "zbateson/mail-mime-parser",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zbateson/mail-mime-parser.git",
+                "reference": "e0d4423fe27850c9dd301190767dbc421acc2f19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zbateson/mail-mime-parser/zipball/e0d4423fe27850c9dd301190767dbc421acc2f19",
+                "reference": "e0d4423fe27850c9dd301190767dbc421acc2f19",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/psr7": "^2.5",
+                "php": ">=8.0",
+                "php-di/php-di": "^6.0|^7.0",
+                "psr/log": "^1|^2|^3",
+                "zbateson/mb-wrapper": "^2.0",
+                "zbateson/stream-decorators": "^2.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "*",
+                "monolog/monolog": "^2|^3",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-iconv": "For best support/performance",
+                "ext-mbstring": "For best support/performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZBateson\\MailMimeParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Zaahid Bateson"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/zbateson/mail-mime-parser/graphs/contributors"
+                }
+            ],
+            "description": "MIME email message parser",
+            "homepage": "https://mail-mime-parser.org",
+            "keywords": [
+                "MimeMailParser",
+                "email",
+                "mail",
+                "mailparse",
+                "mime",
+                "mimeparse",
+                "parser",
+                "php-imap"
+            ],
+            "support": {
+                "docs": "https://mail-mime-parser.org/#usage-guide",
+                "issues": "https://github.com/zbateson/mail-mime-parser/issues",
+                "source": "https://github.com/zbateson/mail-mime-parser"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zbateson",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-10T18:44:09+00:00"
+        },
+        {
+            "name": "zbateson/mb-wrapper",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zbateson/mb-wrapper.git",
+                "reference": "50a14c0c9537f978a61cde9fdc192a0267cc9cff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zbateson/mb-wrapper/zipball/50a14c0c9537f978a61cde9fdc192a0267cc9cff",
+                "reference": "50a14c0c9537f978a61cde9fdc192a0267cc9cff",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "symfony/polyfill-iconv": "^1.9",
+                "symfony/polyfill-mbstring": "^1.9"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "*",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^9.6|^10.0"
+            },
+            "suggest": {
+                "ext-iconv": "For best support/performance",
+                "ext-mbstring": "For best support/performance"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZBateson\\MbWrapper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Zaahid Bateson"
+                }
+            ],
+            "description": "Wrapper for mbstring with fallback to iconv for encoding conversion and string manipulation",
+            "keywords": [
+                "charset",
+                "encoding",
+                "http",
+                "iconv",
+                "mail",
+                "mb",
+                "mb_convert_encoding",
+                "mbstring",
+                "mime",
+                "multibyte",
+                "string"
+            ],
+            "support": {
+                "issues": "https://github.com/zbateson/mb-wrapper/issues",
+                "source": "https://github.com/zbateson/mb-wrapper/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zbateson",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-20T22:05:33+00:00"
+        },
+        {
+            "name": "zbateson/stream-decorators",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zbateson/stream-decorators.git",
+                "reference": "32a2a62fb0f26313395c996ebd658d33c3f9c4e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zbateson/stream-decorators/zipball/32a2a62fb0f26313395c996ebd658d33c3f9c4e5",
+                "reference": "32a2a62fb0f26313395c996ebd658d33c3f9c4e5",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/psr7": "^2.5",
+                "php": ">=8.0",
+                "zbateson/mb-wrapper": "^2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "*",
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^9.6|^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZBateson\\StreamDecorators\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Zaahid Bateson"
+                }
+            ],
+            "description": "PHP psr7 stream decorators for mime message part streams",
+            "keywords": [
+                "base64",
+                "charset",
+                "decorators",
+                "mail",
+                "mime",
+                "psr7",
+                "quoted-printable",
+                "stream",
+                "uuencode"
+            ],
+            "support": {
+                "issues": "https://github.com/zbateson/stream-decorators/issues",
+                "source": "https://github.com/zbateson/stream-decorators/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zbateson",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-29T21:42:39+00:00"
         }
     ],
     "packages-dev": [

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -6,6 +6,7 @@
 
   <div class="p-6">
     <div class="max-w-3xl mx-auto bg-white shadow rounded-xl p-6 space-y-6 dark:bg-gray-800 dark:text-gray-100">
+      
       {{-- Upload form: POST + multipart/form-data to send file --}}
       <form method="POST" action="{{ route('scan.store') }}" enctype="multipart/form-data" class="space-y-4">
         @csrf
@@ -15,7 +16,8 @@
           <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
             Upload .eml file
           </label>
-          <input type="file" name="eml" accept=".eml" required class="block w-full">
+          <input type="file" name="eml" accept=".eml" required 
+                 class="block w-full border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-300">
           <p class="text-xs text-gray-500 mt-1">Max 15MB, MIME: message/rfc822</p>
 
           {{-- Server-side validation error for the file input --}}
@@ -30,11 +32,54 @@
       {{-- Success flash message (from POST handler) --}}
       @if (session('ok'))
         <div class="text-green-700 dark:text-green-400">✅ {{ session('ok') }}</div>
-      @endif>
+      @endif
 
-      {{-- Simple guidance (no parsing yet) --}}
+      {{-- Parsed summary (shown after a successful upload + parsing) --}}
+      @if (session('results'))
+        @php $r = session('results'); @endphp
+        <div class="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+          <h3 class="font-semibold mb-2">Parsed summary</h3>
+          <dl class="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+            <div>
+              <dt class="text-gray-500 dark:text-gray-400">From</dt>
+              <dd>{{ $r['from'] ?? '—' }}</dd>
+            </div>
+            <div>
+              <dt class="text-gray-500 dark:text-gray-400">From domain</dt>
+              <dd>{{ $r['fromDomain'] ?? '—' }}</dd>
+            </div>
+            <div>
+              <dt class="text-gray-500 dark:text-gray-400">To</dt>
+              <dd>{{ $r['to'] ?? '—' }}</dd>
+            </div>
+            <div>
+              <dt class="text-gray-500 dark:text-gray-400">Subject</dt>
+              <dd>{{ $r['subject'] ?? '—' }}</dd>
+            </div>
+            <div>
+              <dt class="text-gray-500 dark:text-gray-400">Date</dt>
+              <dd>{{ $r['date'] ?? '—' }}</dd>
+            </div>
+            <div>
+              <dt class="text-gray-500 dark:text-gray-400">Text length</dt>
+              <dd>{{ $r['bodies']['textLength'] ?? 0 }}</dd>
+            </div>
+            <div>
+              <dt class="text-gray-500 dark:text-gray-400">HTML length</dt>
+              <dd>{{ $r['bodies']['htmlLength'] ?? 0 }}</dd>
+            </div>
+            <div>
+              <dt class="text-gray-500 dark:text-gray-400">Attachments</dt>
+              <dd>{{ $r['attachments']['count'] ?? 0 }}</dd>
+            </div>
+          </dl>
+        </div>
+      @endif
+
+      {{-- Simple guidance --}}
       <p class="text-sm text-gray-600 dark:text-gray-300">
-        This step only validates and accepts the .eml upload. Parsing comes next.
+        This step validates, accepts, and parses the .eml file in memory. 
+        No email content is stored. Next, we will extract URLs.
       </p>
     </div>
   </div>


### PR DESCRIPTION
- switch to zbateson/mail-mime-parser (no PHP extension required)

- extract From/To/Subject/Date + text/html body lengths + attachment count

- no email content persisted; results flashed to session