### PR TITLE
feat(scan): persist parsed scan metadata to database

### DIFF
--- a/app/Models/Scan.php
+++ b/app/Models/Scan.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Scan extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'from','from_domain','to','subject',
+        'date_raw','date_iso',
+        'text_length','html_length','raw_size',
+        'attachments_count','urls_count',
+        'urls_json',
+    ];
+
+    protected $casts = [
+        'date_iso' => 'datetime',
+        'urls_json' => 'array',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_08_19_150757_create_scan_table.php
+++ b/database/migrations/2025_08_19_150757_create_scan_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('scans', function (Blueprint $table) {
+            $table->id();
+
+            // Link scan to the user who uploaded the .eml
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+
+            // Basic headers (store minimal PII only)
+            $table->string('from')->nullable();
+            $table->string('from_domain')->nullable();
+            $table->string('to')->nullable();
+            $table->string('subject')->nullable();
+
+            // Dates
+            $table->string('date_raw')->nullable();      // as-is from the email header
+            $table->timestamp('date_iso')->nullable();   // normalized (Carbon) if parseable
+
+            // Bodies (lengths only; no content persisted)
+            $table->unsignedInteger('text_length')->default(0);
+            $table->unsignedInteger('html_length')->default(0);
+            $table->unsignedInteger('raw_size')->default(0); // bytes of the raw .eml
+
+            // Attachments & URLs
+            $table->unsignedInteger('attachments_count')->default(0);
+            $table->unsignedInteger('urls_count')->default(0);
+
+            // Optional: store the extracted URLs as JSON for convenience (no body content)
+            $table->json('urls_json')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('scans');
+    }
+};

--- a/resources/views/history.blade.php
+++ b/resources/views/history.blade.php
@@ -1,13 +1,56 @@
-{{-- Protected "History" page (app layout) --}}
+{{-- resources/views/history.blade.php --}}
 <x-app-layout>
+  {{-- ---------- Header ---------- --}}
   <x-slot name="header">
     <h2 class="font-semibold text-xl">History</h2>
   </x-slot>
 
   <div class="p-6">
-    <div class="max-w-4xl mx-auto bg-white shadow rounded-xl p-6">
-      <p class="text-gray-700">
-        Scan results will be listed here once we implement persistence.
+    <div class="max-w-3xl mx-auto bg-white shadow rounded-xl p-6 space-y-6 dark:bg-gray-800 dark:text-gray-100">
+
+      @if ($scans->count() === 0)
+        <div class="rounded-lg border border-gray-200 p-4 text-sm text-gray-600 text-center dark:text-gray-300 dark:border-gray-700">
+          No scans yet. Upload an .eml file on the
+          <a href="{{ route('scan.create') }}" class="text-blue-600 dark:text-blue-400 hover:underline">Scan</a> page.
+        </div>
+      @else
+        <div class="overflow-x-auto rounded-xl border border-gray-200 dark:border-gray-700">
+          <table class="min-w-full text-sm">
+            <thead class="bg-gray-50 dark:bg-gray-700/60 text-gray-700 dark:text-gray-200">
+              <tr class="text-center">
+                <th class="px-6 py-4 text-base font-bold">When</th>
+                <th class="px-6 py-4 text-base font-bold">From</th>
+                <th class="px-6 py-4 text-base font-bold">Subject</th>
+                <th class="px-6 py-4 text-base font-bold">URLs</th>
+                <th class="px-6 py-4 text-base font-bold">Attachments</th>
+                <th class="px-6 py-4 text-base font-bold">Size</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+              @foreach ($scans as $scan)
+                <tr class="text-center odd:bg-white even:bg-gray-50 dark:odd:bg-gray-800 dark:even:bg-gray-800/70">
+                  <td class="px-6 py-4 whitespace-nowrap">
+                    {{ optional($scan->created_at)->format('Y-m-d H:i') }}
+                  </td>
+                  <td class="px-6 py-4 break-all">{{ $scan->from ?? '—' }}</td>
+                  <td class="px-6 py-4 break-all">{{ $scan->subject ?? '—' }}</td>
+                  <td class="px-6 py-4">{{ $scan->urls_count }}</td>
+                  <td class="px-6 py-4">{{ $scan->attachments_count }}</td>
+                  <td class="px-6 py-4">{{ number_format($scan->raw_size) }} bytes</td>
+                </tr>
+              @endforeach
+            </tbody>
+          </table>
+        </div>
+
+        {{-- Centered pagination --}}
+        <div class="mt-4 flex justify-center">
+          {{ $scans->links() }}
+        </div>
+      @endif
+
+      <p class="text-sm text-gray-600 dark:text-gray-300">
+        This page lists saved scans (metadata only). No email body is stored.
       </p>
     </div>
   </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ProfileController;
-use App\Http\Controllers\ScanController; // <-- add controller import
+use App\Http\Controllers\ScanController; // controller for scan + history
 
 // ---------- Public pages ----------
 Route::view('/', 'home')->name('home');          // serves resources/views/home.blade.php
@@ -15,15 +15,17 @@ Route::view('/dashboard', 'dashboard')
 
 // ---------- Private pages (login + verified email required) ----------
 Route::middleware(['auth', 'verified'])->group(function () {
-    // GET: scan page (form)
-    Route::view('/scan', 'create')->name('scan.create');        // serves resources/views/create.blade.php
+    // Scan page (form)
+    Route::view('/scan', 'create')->name('scan.create'); // resources/views/create.blade.php
 
-    // POST: scan upload handler (controller, validation only — no parsing)
+    // Upload handler (validation + parse + persist)
     Route::post('/scan', [ScanController::class, 'store'])->name('scan.store');
 
-    // Other protected pages (placeholders)
-    Route::view('/history', 'history')->name('scan.history');   // resources/views/history.blade.php
-    Route::view('/stats', 'stats')->name('stats');              // resources/views/stats.blade.php
+    // History (now uses controller action to fetch paginated scans)
+    Route::get('/history', [ScanController::class, 'history'])->name('scan.history');
+
+    // Stats (placeholder view for now)
+    Route::view('/stats', 'stats')->name('stats'); // resources/views/stats.blade.php
 });
 
 // ---------- Breeze profile pages (login required) ----------


### PR DESCRIPTION
- add migration for scans table (from, subject, urls_count, attachments_count, raw_size, etc.)

- update ScanController@store to save parsed results in DB

- implement History page listing scans with pagination

- improve table UI: centered layout, larger bold headers, better spacing

- only lightweight metadata stored (no email body)