### PR TITLE
feat(scan): submit extracted URLs to urlscan.io and store per-URL status

### DIFF
--- a/app/Models/Scan.php
+++ b/app/Models/Scan.php
@@ -4,25 +4,34 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Scan extends Model
 {
     protected $fillable = [
         'user_id',
-        'from','from_domain','to','subject',
-        'date_raw','date_iso',
-        'text_length','html_length','raw_size',
-        'attachments_count','urls_count',
+        'from', 'from_domain', 'to', 'subject',
+        'date_raw', 'date_iso',
+        'text_length', 'html_length', 'raw_size',
+        'attachments_count', 'urls_count',
         'urls_json',
     ];
 
     protected $casts = [
-        'date_iso' => 'datetime',
+        'date_iso'  => 'datetime',
         'urls_json' => 'array',
     ];
 
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Related URL submissions (each extracted URL sent to urlscan.io).
+     */
+    public function urls(): HasMany
+    {
+        return $this->hasMany(ScanUrl::class);
     }
 }

--- a/app/Models/ScanUrl.php
+++ b/app/Models/ScanUrl.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ScanUrl extends Model
+{
+    protected $fillable = [
+        'scan_id', 'url', 'host', 'visibility', 'status',
+        'urlscan_uuid', 'result_url', 'error_code', 'error_message',
+        'submitted_at',
+    ];
+
+    protected $casts = [
+        'submitted_at' => 'datetime',
+    ];
+
+    public function scan()
+    {
+        return $this->belongsTo(Scan::class);
+    }
+}

--- a/config/urlscan.php
+++ b/config/urlscan.php
@@ -1,12 +1,60 @@
 <?php
 
 return [
-    // Base API URL
-    'base'   => env('URLSCAN_BASE', 'https://urlscan.io/api'),
 
-    // Your API key (optional for search, recommended for submit/private scans)
-    'key'    => env('URLSCAN_API_KEY'),
+    /*
+    |--------------------------------------------------------------------------
+    | Base API URL
+    |--------------------------------------------------------------------------
+    |
+    | Default urlscan.io API endpoint.
+    |
+    */
+    'base' => env('URLSCAN_BASE', 'https://urlscan.io/api'),
 
-    // Default public setting when submitting a URL (true = public)
-    'public' => env('URLSCAN_PUBLIC', true),
+    /*
+    |--------------------------------------------------------------------------
+    | API Key
+    |--------------------------------------------------------------------------
+    |
+    | Needed for submissions (especially private/unlisted scans).
+    | Optional for search queries.
+    |
+    */
+    'key' => env('URLSCAN_API_KEY'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Visibility for submissions
+    |--------------------------------------------------------------------------
+    |
+    | 'public'   = visible to everyone
+    | 'unlisted' = only visible via direct link (still stored on urlscan)
+    | 'private'  = requires API key, not shared
+    |
+    */
+    'visibility' => env('URLSCAN_VISIBILITY', 'unlisted'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Feature toggle
+    |--------------------------------------------------------------------------
+    |
+    | Allow disabling urlscan integration easily.
+    |
+    */
+    'enabled' => env('URLSCAN_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Limits
+    |--------------------------------------------------------------------------
+    |
+    | Max URLs per scan (to avoid abuse/mistakes).
+    | Sleep time in milliseconds between API calls (rate limiting).
+    |
+    */
+    'max_per_scan'   => env('URLSCAN_MAX_PER_SCAN', 5),
+    'rate_sleep_ms'  => env('URLSCAN_RATE_SLEEP_MS', 300),  // 0.3s
+
 ];

--- a/database/migrations/2025_08_20_123747_create_scan_urls_table.php
+++ b/database/migrations/2025_08_20_123747_create_scan_urls_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('scan_urls', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('scan_id')->constrained()->cascadeOnDelete();
+
+            $table->string('url', 2048);
+            $table->string('host')->nullable();
+
+            // urlscan submission control/result
+            $table->string('visibility', 16)->default('unlisted'); // public|unlisted
+            $table->string('status', 20)->default('submitted');    // submitted|blocked|rate_limited|error
+            $table->string('urlscan_uuid', 64)->nullable();
+            $table->string('result_url')->nullable();
+
+            // errors
+            $table->string('error_code')->nullable();
+            $table->text('error_message')->nullable();
+
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('scan_urls');
+    }
+};

--- a/resources/views/scans/show.blade.php
+++ b/resources/views/scans/show.blade.php
@@ -1,4 +1,4 @@
-{{-- resources/views/show.blade.php --}}
+{{-- resources/views/scans/show.blade.php --}}
 <x-app-layout>
   <x-slot name="header">
     <div class="flex justify-between items-center">
@@ -50,21 +50,28 @@
         </dl>
       </div>
 
-      {{-- Extracted URLs --}}
-      @php
-        $urls = is_array($scan->urls_json) ? $scan->urls_json : (json_decode($scan->urls_json ?? '[]', true) ?: []);
-      @endphp
-
-      @if (!empty($urls))
+      {{-- Extracted URLs + urlscan submission status --}}
+      @if ($scan->urls->count() > 0)
         <div class="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
-          <h3 class="font-semibold mb-2">Extracted URLs ({{ count($urls) }})</h3>
-          <ul class="list-disc ms-5 space-y-1 text-sm">
-            @foreach ($urls as $u)
-              <li>
-                <a href="{{ $u }}" target="_blank" rel="noopener noreferrer nofollow"
-                   class="text-blue-600 dark:text-blue-400 hover:underline break-all">
-                  {{ $u }}
-                </a>
+          <h3 class="font-semibold mb-2">Extracted URLs ({{ $scan->urls->count() }})</h3>
+          <ul class="space-y-2 text-sm">
+            @foreach ($scan->urls as $url)
+              <li class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 border-b border-gray-200 dark:border-gray-700 pb-2">
+                <div class="break-all">
+                  <a href="{{ $url->url }}" target="_blank" rel="noopener noreferrer nofollow"
+                     class="text-blue-600 dark:text-blue-400 hover:underline">
+                    {{ $url->url }}
+                  </a>
+                </div>
+                <div class="text-xs text-gray-600 dark:text-gray-300">
+                  @if ($url->status === 'submitted' && $url->result_url)
+                    ✅ Submitted → <a href="{{ $url->result_url }}" target="_blank" class="underline">View</a>
+                  @elseif ($url->status === 'error')
+                    ❌ Error: {{ $url->error_message }}
+                  @else
+                    ⏳ {{ ucfirst($url->status) }}
+                  @endif
+                </div>
               </li>
             @endforeach
           </ul>
@@ -76,7 +83,8 @@
       @endif
 
       <div class="pt-2 text-sm text-gray-600 dark:text-gray-300">
-        This page shows saved scan metadata. The original email body is never stored for privacy reasons.
+        This page shows saved scan metadata and submission status.  
+        The original email body is never stored for privacy reasons.
       </div>
 
     </div>


### PR DESCRIPTION
- Add UrlscanClient (search/submit/result) with retries/timeouts

- New ScanUrl model + migration to track each submission (status, uuid, result URL, errors)

- Controller: parse .eml, persist Scan, rate-limit and submit first N URLs; record outcomes

- Show URL submission status in Scan Details; link to urlscan result

- Config: URLSCAN_ENABLED, URLSCAN_VISIBILITY, MAX_PER_SCAN, RATE_SLEEP_MS

- Privacy: never store email bodies (metadata only)