### PR TITLE
feat(urlscan): integrate urlscan.io submissions

### DIFF
--- a/database/migrations/2025_08_20_123747_create_scan_urls_table.php
+++ b/database/migrations/2025_08_20_123747_create_scan_urls_table.php
@@ -16,9 +16,9 @@ return new class extends Migration
             $table->string('host')->nullable();
 
             // urlscan submission control/result
-            $table->string('visibility', 16)->default('unlisted'); // public|unlisted
-            $table->string('status', 20)->default('submitted');    // submitted|blocked|rate_limited|error
-            $table->string('urlscan_uuid', 64)->nullable();
+            $table->string('visibility', 16)->default('unlisted'); 
+            $table->string('status', 20)->default('queued'); // queued|submitted|finished|blocked|rate_limited|error
+            $table->string('result_uuid', 64)->nullable();   // renamed from urlscan_uuid
             $table->string('result_url')->nullable();
 
             // errors
@@ -26,6 +26,7 @@ return new class extends Migration
             $table->text('error_message')->nullable();
 
             $table->timestamp('submitted_at')->nullable();
+            $table->timestamp('finished_at')->nullable(); // new: when marked finished
             $table->timestamps();
         });
     }


### PR DESCRIPTION
- Added ScanUrl migration/table to track per-URL submissions (url, host, visibility, status, uuid, result_url, error fields).
- Updated Scan model with hasMany('urls') relation.
- Extended ScanController@store to submit up to N URLs to urlscan.io: • respects URLSCAN_ENABLED, MAX_PER_SCAN, VISIBILITY, RATE_SLEEP_MS • stores each submission attempt in scan_urls • records uuid/result_url if successful, or error details otherwise
- Updated config/urlscan.php for visibility, enabled flag, limits, rate sleep.
- This lays groundwork for step 5.2 (result polling & verdicts).