### PR TITLE
feat(scan): add SPF DNS verification (step 5.2)

### DIFF
--- a/app/Models/Scan.php
+++ b/app/Models/Scan.php
@@ -15,11 +15,13 @@ class Scan extends Model
         'text_length', 'html_length', 'raw_size',
         'attachments_count', 'urls_count',
         'urls_json',
+        'spf_json', // <-- NEW
     ];
 
     protected $casts = [
         'date_iso'  => 'datetime',
         'urls_json' => 'array',
+        'spf_json'  => 'array',   // <-- NEW
     ];
 
     public function user(): BelongsTo

--- a/app/Services/DnsSpf.php
+++ b/app/Services/DnsSpf.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Services;
+
+class DnsSpf
+{
+    /**
+     * Check SPF for a domain.
+     * Returns a compact summary for display/storage.
+     */
+    public function check(string $domain): array
+    {
+        $result = [
+            'domain'       => strtolower($domain),
+            'exists'       => false,
+            'record'       => null,
+            'policy'       => 'none',   // none | pass | fail | softfail | neutral | unknown
+            'has_include'  => false,
+            'has_ip4'      => false,
+            'has_ip6'      => false,
+            'has_a'        => false,
+            'has_mx'       => false,
+            'has_ptr'      => false,
+            'mechanisms'   => [],
+            'warnings'     => [],
+        ];
+
+        if ($domain === '') {
+            return $result;
+        }
+
+        // Fetch TXT records
+        $txts = @dns_get_record($domain, DNS_TXT) ?: [];
+
+        // Pick the first SPF record (starts with v=spf1)
+        $spf = null;
+        foreach ($txts as $rec) {
+            $txt = $rec['txt'] ?? '';
+            if (stripos($txt, 'v=spf1') === 0) {
+                $spf = $txt;
+                break;
+            }
+        }
+
+        if (!$spf) {
+            // no SPF
+            return $result;
+        }
+
+        $result['exists'] = true;
+        $result['record'] = $spf;
+
+        // Tokenize by spaces (very simple tokenizer)
+        $tokens = preg_split('/\s+/', trim($spf)) ?: [];
+
+        // Parse mechanisms
+        foreach ($tokens as $tok) {
+            if ($tok === '' || stripos($tok, 'v=spf1') === 0) continue;
+
+            $result['mechanisms'][] = $tok;
+
+            // flags
+            if (str_starts_with($tok, 'include:')) $result['has_include'] = true;
+            if (str_starts_with($tok, 'ip4:'))     $result['has_ip4']     = true;
+            if (str_starts_with($tok, 'ip6:'))     $result['has_ip6']     = true;
+            if (preg_match('~^[+\-~?]?a(?::|/|$)~i', $tok))   $result['has_a']  = true;
+            if (preg_match('~^[+\-~?]?mx(?::|/|$)~i', $tok))  $result['has_mx'] = true;
+            if (stripos($tok, 'ptr') === 0 || preg_match('~^[+\-~?]?ptr~i', $tok)) $result['has_ptr'] = true;
+        }
+
+        // Determine policy from the *all mechanism (if present)
+        // e.g.  -all  => fail,  ~all => softfail,  ?all => neutral, +all => pass
+        $policy = 'unknown';
+        foreach (array_reverse($tokens) as $tok) {
+            if (preg_match('~^([+\-~?])?all$~i', $tok, $m)) {
+                $q = $m[1] ?? '+';
+                $policy = match ($q) {
+                    '-' => 'fail',
+                    '~' => 'softfail',
+                    '?' => 'neutral',
+                    '+', '' => 'pass',
+                    default => 'unknown',
+                };
+                break;
+            }
+        }
+        $result['policy'] = $policy;
+
+        if ($result['has_ptr']) {
+            $result['warnings'][] = 'Uses PTR (discouraged).';
+        }
+        if ($policy === 'pass' && !$result['has_ip4'] && !$result['has_ip6'] && !$result['has_include'] && !$result['has_a'] && !$result['has_mx']) {
+            $result['warnings'][] = 'Policy "pass" but no explicit mechanisms.';
+        }
+
+        return $result;
+    }
+}

--- a/database/migrations/2025_08_20_140506_add_spf_to_scans_table.php
+++ b/database/migrations/2025_08_20_140506_add_spf_to_scans_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('scans', function (Blueprint $table) {
+            $table->json('spf_json')->nullable()->after('urls_json');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('scans', function (Blueprint $table) {
+            $table->dropColumn('spf_json');
+        });
+    }
+};

--- a/resources/views/scans/show.blade.php
+++ b/resources/views/scans/show.blade.php
@@ -50,6 +50,26 @@
         </dl>
       </div>
 
+      {{-- SPF info --}}
+      @php
+        $spf = is_array($scan->spf_json) ? $scan->spf_json : (json_decode($scan->spf_json ?? '[]', true) ?: []);
+      @endphp
+      <div class="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+        <h3 class="font-semibold mb-2">SPF Verification</h3>
+        @if (!empty($spf['found']) && !empty($spf['records']))
+          <p class="text-sm mb-2 text-green-700 dark:text-green-400">✅ SPF record(s) found for {{ $scan->from_domain }}</p>
+          <ul class="list-disc ms-5 text-sm space-y-1">
+            @foreach ($spf['records'] as $rec)
+              <li class="break-all">{{ $rec }}</li>
+            @endforeach
+          </ul>
+        @elseif (!empty($spf['error']))
+          <p class="text-sm text-red-600 dark:text-red-400">⚠️ SPF lookup error: {{ $spf['error'] }}</p>
+        @else
+          <p class="text-sm text-gray-600 dark:text-gray-300">No SPF record found for {{ $scan->from_domain ?? 'domain' }}.</p>
+        @endif
+      </div>
+
       {{-- Extracted URLs + urlscan submission status --}}
       @if ($scan->urls->count() > 0)
         <div class="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
@@ -70,7 +90,6 @@
                   @endphp
 
                   @if (!empty($u->result_url))
-                    {{-- Show a View link whenever urlscan gave us a result URL --}}
                     <span class="mr-1">✅ {{ $label }}</span>
                     <a href="{{ $u->result_url }}" target="_blank" class="underline">View</a>
                   @elseif ($u->status === 'error')
@@ -94,7 +113,7 @@
       @endif
 
       <div class="pt-2 text-sm text-gray-600 dark:text-gray-300">
-        This page shows saved scan metadata and submission status.
+        This page shows saved scan metadata, SPF info, and submission status.  
         The original email body is never stored for privacy reasons.
       </div>
 


### PR DESCRIPTION
- Added  column in scans table to store SPF DNS records
- Implemented SPF lookup in ScanController@store using dns_get_record
- Persisted SPF results in
- Updated Scan model to cast  as array
- Updated scan details view to display SPF verification results