### PR TITLE
feat(scan): add DMARC verification support to scans

### DIFF
--- a/app/Models/Scan.php
+++ b/app/Models/Scan.php
@@ -15,13 +15,15 @@ class Scan extends Model
         'text_length', 'html_length', 'raw_size',
         'attachments_count', 'urls_count',
         'urls_json',
-        'spf_json', // <-- NEW
+        'spf_json',          // from step 5.2 (SPF)
+        'dmarc_json',        // NEW (DMARC)
     ];
 
     protected $casts = [
-        'date_iso'  => 'datetime',
-        'urls_json' => 'array',
-        'spf_json'  => 'array',   // <-- NEW
+        'date_iso'   => 'datetime',
+        'urls_json'  => 'array',
+        'spf_json'   => 'array',
+        'dmarc_json' => 'array',
     ];
 
     public function user(): BelongsTo
@@ -29,9 +31,7 @@ class Scan extends Model
         return $this->belongsTo(User::class);
     }
 
-    /**
-     * Related URL submissions (each extracted URL sent to urlscan.io).
-     */
+    /** Related URL submissions (each extracted URL sent to urlscan.io). */
     public function urls(): HasMany
     {
         return $this->hasMany(ScanUrl::class);

--- a/database/migrations/2025_08_20_143454_add_dmarc_to_scans_table.php
+++ b/database/migrations/2025_08_20_143454_add_dmarc_to_scans_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('scans', function (Blueprint $table) {
+            if (!Schema::hasColumn('scans', 'dmarc_json')) {
+                $table->json('dmarc_json')->nullable()->after('spf_json');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('scans', function (Blueprint $table) {
+            if (Schema::hasColumn('scans', 'dmarc_json')) {
+                $table->dropColumn('dmarc_json');
+            }
+        });
+    }
+};


### PR DESCRIPTION
- Added  column to  table (JSON) via migration
- Updated Scan model to make  fillable and casted as array
- Extended ScanController to:
  - Lookup DMARC TXT records at _dmarc.<domain>
  - Parse policy (p=reject/quarantine/none)
  - Store DMARC lookup result in DB
  - Expose DMARC info to views
- Updated scan details view (show.blade.php) to display DMARC badge:
  - Shows strong (reject), medium (quarantine), weak (none), missing, or lookup error